### PR TITLE
Chakra is using Calamares

### DIFF
--- a/about.md
+++ b/about.md
@@ -36,6 +36,7 @@ Many Linux distributions are in varying stages of adopting Calamares as their pr
 Operating systems that already ship Calamares:
 
 - [BBQLinux](http://bbqlinux.org/)
+- [Chakra](https://chakraos.org/)
 - [KaOS](http://kaosx.us/)
 - [Kogaion](http://rogentos.ro/)
 - [Manjaro](http://manjaro.org/)


### PR DESCRIPTION
With the release of [Fermi](https://chakraos.org/news/index.php?/archives/156-Chakra-2015.11-Fermi-released.html) **Tribe** was dropped in favour of **Calamares**.