### PR TITLE
A couple of improvements to deploycala

### DIFF
--- a/deploycala.py
+++ b/deploycala.py
@@ -206,8 +206,8 @@ def main():
     parser.add_argument("-i", "--incremental", action="store_true", dest="incremental",
                         help="do incremental builds, i.e. don't clear the build directory before building, if found")
     parser.add_argument("--noupdate", action="store_true", dest="noupdate", help=argparse.SUPPRESS)
-    parser.add_argument("-u", "--url", nargs=1, default=None, dest="url",
-                        help="change the remote URL we clone Calamares from.")
+    parser.add_argument("-u", "--url", nargs=1, default="https://github.com/calamares/calamares.git",
+                        dest="url", help="change the remote URL we clone Calamares from.")
     args = parser.parse_args()
 
     if not args.noupdate:
@@ -275,13 +275,8 @@ def main():
         if args.nopull:
             bail("existing clone not found, can't build without pulling.")
 
-        if args.url:
-            url = args.url[0]
-        else:
-            url = "https://github.com/calamares/calamares.git"
-
         message("Cloning and checking out " + branch + " branch...")
-        os.system("git clone %s" % url)
+        os.system("git clone %s" % args.url)
         os.chdir("calamares")
         os.system("git checkout --track origin/"+ branch +" -b " + branch)
         os.system("git submodule init")

--- a/deploycala.py
+++ b/deploycala.py
@@ -103,7 +103,8 @@ def pacman_update(noupgrade):
                 "flex", "gcc", "gcc-libs-multilib", "libtool", "m4", "make",
                 "patch", "cmake", "extra-cmake-modules", "boost", "qt5-tools",
                 "kiconthemes", "kservice", "kio", "kparts", "qtcreator", "ack",
-                "qt5-webengine"]
+                "qt5-webengine", "kpmcore", "qt5-location", "icu", "qt5-declarative",
+                "qt5-translations", "qt5-xmlpatterns"]
     if noupgrade:
         os.system("sudo pacman -Sy --noconfirm --needed --force " + " ".join(packages))
     else:

--- a/deploycala.py
+++ b/deploycala.py
@@ -205,6 +205,8 @@ def main():
     parser.add_argument("-i", "--incremental", action="store_true", dest="incremental",
                         help="do incremental builds, i.e. don't clear the build directory before building, if found")
     parser.add_argument("--noupdate", action="store_true", dest="noupdate", help=argparse.SUPPRESS)
+    parser.add_argument("-u", "--url", nargs=1, default=None, dest="url",
+                        help="change the remote URL we clone Calamares from.")
     args = parser.parse_args()
 
     if not args.noupdate:
@@ -272,8 +274,13 @@ def main():
         if args.nopull:
             bail("existing clone not found, can't build without pulling.")
 
+        if args.url:
+            url = args.url[0]
+        else:
+            url = "https://github.com/calamares/calamares.git"
+
         message("Cloning and checking out " + branch + " branch...")
-        os.system("git clone https://github.com/calamares/calamares.git")
+        os.system("git clone %s" % url)
         os.chdir("calamares")
         os.system("git checkout --track origin/"+ branch +" -b " + branch)
         os.system("git submodule init")


### PR DESCRIPTION
As promised!

1. Allow to set the remote URL we clone from (useful when I was testing from my fork)
2. Add required packages to update list; Calamares complained when they were outdated; 'icu' was especially hard to track down as the name of the library is longer.