### PR TITLE
Move Hamara Linux to OS that ship Calamares

### DIFF
--- a/about.md
+++ b/about.md
@@ -43,6 +43,7 @@ Operating systems that already ship Calamares:
 - [Bluestar Linux](http://bluestarlinux.sourceforge.net/)
 - [Chakra](https://chakraos.org/)
 - [GeckoLinux](http://geckolinux.github.io/)
+- [Hamara Linux](https://www.hamaralinux.org/)
 - [Kannolo](https://kannolo.sourceforge.io/) (Fedora Remix)
 - [KaOS](http://kaosx.us/)
 - [KDE Neon](https://neon.kde.org/)
@@ -62,7 +63,6 @@ Operating systems that already ship Calamares:
 Operating systems that are evaluating Calamares in pre-release builds:
 
 - [Frugalware](https://frugalware.org/)
-- [Hamara Linux](https://www.hamaralinux.org/)
 - [Lubuntu](http://lubuntu.me/)
 - [Maui](http://www.maui-project.org/)
 - [Parabola](https://www.parabola.nu/)


### PR DESCRIPTION
Hamara Linux has recently released Hamara Sugam 2.0 that ships Calamares
and proudly presents Calamares installer as one of the main features.
Hamara Linux is one of the few debian based distros that ship Calamares.
Remove Hamara Linux from the list of OS which include Calamares in their
pre-release builds and add it to the list of OS which add Calamares
in their actual releases.

Source: https://www.hamaralinux.org/2018/07/hamara-sugam-2-0-releases/