### PR TITLE
fix url to SwagArch Gnu/Linux

### DIFF
--- a/about.md
+++ b/about.md
@@ -59,7 +59,7 @@ Operating systems that already ship Calamares:
 - [Redcore Linux](http://redcorelinux.org/)
 - [Sabayon](https://www.sabayon.org/)
 - [Siduction](https://siduction.org/)
-- [SwagArch](https://swagarch.github.io/)
+- [SwagArch](https://swagarch.gitlab.io/)
 - [Tanglu](http://tanglu.org/)
 
 Operating systems that are evaluating Calamares in pre-release builds:


### PR DESCRIPTION
the old github page was Hijacked!